### PR TITLE
hot-fix: remove o mySQL do docker-compose.yml para se adaptar a nova arquitetura com o banco de dados isolado

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,30 +8,6 @@ services:
     ports:
       - "3000:3000"
     environment:
-      - DATABASE_URL=mysql://${MYSQL_USER}:${MYSQL_PASSWORD}@mysql:3306/${MYSQL_DATABASE}
       - NODE_ENV=production
       - HOST=0.0.0.0
     restart: unless-stopped
-    depends_on:
-      mysql:
-        condition: service_healthy
-  mysql:
-    image: mysql:8.0
-    container_name: museu_mysql
-    restart: always
-    environment:
-      MYSQL_DATABASE: ${MYSQL_DATABASE}
-      MYSQL_USER: ${MYSQL_USER}
-      MYSQL_PASSWORD: ${MYSQL_PASSWORD}
-      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
-    ports:
-      - "3306:3306"
-    volumes:
-      - mysql_data:/var/lib/mysql
-    healthcheck:
-      test: ["CMD", "mysqladmin" ,"ping", "-h", "localhost"]
-      timeout: 20s
-      retries: 10
-
-volumes:
-  mysql_data:


### PR DESCRIPTION
This pull request removes the MySQL service configuration from the `docker-compose.yml` file, simplifying the setup by eliminating database dependencies within the Docker environment.

Key changes in `docker-compose.yml`:

* Removed the `mysql` service configuration, including its image, container settings, environment variables, ports, volumes, and health check.
* Deleted the `DATABASE_URL` environment variable and the `depends_on` directive for the MySQL service from the main application service.
* Removed the `volumes` section, which previously defined `mysql_data` for persisting MySQL data.